### PR TITLE
refactor reducer

### DIFF
--- a/src/RootContext.ts
+++ b/src/RootContext.ts
@@ -5,7 +5,7 @@ export const initialState: AppState = {
     datasetNames: [],
     datasetMetadata: null,
     selectedDataset: "",
-    selectedCovariates: [],
+    datasetSettings: {},
     uploadError: null,
     genericError: null,
     language: "en"
@@ -26,30 +26,6 @@ export enum ActionType {
 export interface RootAction {
     type: ActionType
     payload: any
-}
-
-export const rootReducer = (state: AppState, action: RootAction): AppState => {
-    console.log(action.type);
-    switch (action.type) {
-        case ActionType.ERROR_ADDED:
-            return {...state, genericError: action.payload}
-        case ActionType.ERROR_DISMISSED:
-            return {...state, genericError: null}
-        case ActionType.UPLOAD_ERROR_ADDED:
-            return {...state, uploadError: action.payload}
-        case ActionType.UPLOAD_ERROR_DISMISSED:
-            return {...state, uploadError: null}
-        case ActionType.DATASET_NAMES_FETCHED:
-            return {...state, datasetNames: action.payload}
-        case ActionType.DATASET_SELECTED:
-            return {...state, selectedDataset: action.payload}
-        case ActionType.DATASET_METADATA_FETCHED:
-            return {...state, datasetMetadata: action.payload}
-        case ActionType.SELECT_COVARIATE:
-            return {...state, selectedCovariates: [...state.selectedCovariates, action.payload]}
-        case ActionType.UNSELECT_COVARIATE:
-            return {...state, selectedCovariates: state.selectedCovariates.filter(v => v.name !== action.payload)}
-    }
 }
 
 export const RootContext = createContext<AppState>(initialState);

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,17 +1,17 @@
 import React, {useEffect, useReducer} from 'react';
 import {Container} from "react-bootstrap";
 import TopNav from "./TopNav";
-import {ChooseDataset} from "./ChooseDataset";
+import {ChooseOrUploadDataset} from "./ChooseOrUploadDataset";
 import usePersistedState from "../hooks/usePersistedState";
 import {
     initialState,
     RootContext,
-    RootDispatchContext,
-    rootReducer
+    RootDispatchContext
 } from "../RootContext";
 import {ExploreDataset} from "./ExploreDataset";
 import AppError from "./AppError";
 import {dataService} from "../services/dataService";
+import {rootReducer} from "../reducers/rootReducer";
 
 export default function App() {
     const [theme, setTheme] = usePersistedState<string>("theme", "dark");
@@ -37,7 +37,7 @@ export default function App() {
                     setTheme={setTheme as (newState: string) => void}></TopNav>
             <AppError/>
             <Container fluid>
-                {!state.selectedDataset && <ChooseDataset/>}
+                {!state.selectedDataset && <ChooseOrUploadDataset/>}
                 {state.selectedDataset && <ExploreDataset/>}
             </Container>
         </RootDispatchContext.Provider>

--- a/src/components/ChooseDataset.tsx
+++ b/src/components/ChooseDataset.tsx
@@ -1,166 +1,27 @@
-import React, {useContext, useEffect, useState} from 'react';
-import {Button, Col, Row} from "react-bootstrap";
 import Form from "react-bootstrap/Form";
-import {ActionType, RootContext, RootDispatchContext} from "../RootContext";
-import {api} from "../services/apiService";
-import {DataService} from "../services/dataService";
+import React, {useContext} from "react";
+import {RootContext} from "../RootContext";
 
-export function ChooseDataset() {
+interface Props {
+    selectedDataset: string;
+    selectDataset: (name: string) => void
+}
+
+export default function ChooseDataset({selectedDataset, selectDataset}: Props) {
 
     const state = useContext(RootContext);
-    const dispatch = useContext(RootDispatchContext);
-    const apiService = api(state.language, dispatch);
-
-    useEffect(() => {
-        (new DataService(api(state.language, dispatch)))
-            .getDatasetNames();
-
-    }, [state.language, dispatch]);
-
-    useEffect(() => {
-        if (state.datasetNames.length > 0) {
-            selectDataset(state.datasetNames[0]);
-        }
-    }, [state.datasetNames]);
 
     const onSelectData = (event: any) => {
         selectDataset(event.target.value);
     }
 
-    const go = (event: any) => {
-        event.preventDefault();
-        dispatch({type: ActionType.DATASET_SELECTED, payload: selectedDataset})
-    }
-
-    const [selectedDataset, selectDataset] = useState(state.datasetNames.length > 0 ? state.datasetNames[0] : "");
-    const [showOptions, setShowOptions] = useState(false);
-    const [timeColumnHeader, setTimeColumnHeader] = useState("day");
-    const [timeColumnName, setTimeColumnName] = useState("Day of study");
-    const [selectedFile, selectFile] = useState("");
-    const [isUploading, setIsUploading] = useState(false);
-
-    const toggleShowOptions = (event: any) => {
-        event.preventDefault();
-        setShowOptions(!showOptions);
-    }
-    const onSelectTimeColumnHeader = (e: any) => setTimeColumnHeader(e.target.value);
-    const onSelectTimeColumnName = (e: any) => setTimeColumnName(e.target.value);
-
-    const uploadNewFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
-        if (event.currentTarget.files?.length) {
-            dispatch({
-                type: ActionType.UPLOAD_ERROR_DISMISSED,
-                payload: null
-            });
-            const file = event.currentTarget.files[0];
-            setIsUploading(true);
-
-            const formData = new FormData();
-            formData.append('file', file);
-            formData.append('xcol', "day");
-
-            const dataService = new DataService(apiService);
-
-            const result = await dataService.uploadDataset(formData);
-
-            setIsUploading(false);
-            selectFile("");
-
-            if (result) {
-                await dataService.getDatasetNames();
-                dispatch({
-                    type: ActionType.DATASET_SELECTED,
-                    payload: result.data
-                });
-            }
-        }
-    }
-
-    return <Row className={"mt-5"}>
-        <Col xs={12} sm={{span: 6, offset: 3}}>
-            <Form>
-                <fieldset>
-                    {state.datasetNames.length > 0 &&
-                        [
-                            <Form.Group key="choose-dataset">
-                                <Form.Label htmlFor="data">Choose
-                                    dataset</Form.Label>
-                                <Form.Select id="data" onChange={onSelectData}
-                                             value={selectedDataset}>
-                                    {state.datasetNames.map((d: string) =>
-                                        <option key={d} value={d}>{d}</option>)}
-                                </Form.Select>
-                            </Form.Group>,
-                            <Button key="go-btn" variant="success"
-                                    className={"w-100 mt-2 mb-3"}
-                                    type="submit" onClick={go}>Go
-                            </Button>,
-                            <h5 key="or-text"
-                                className={"text-center text-uppercase"}>or</h5>
-                        ]
-                    }
-                    <Form.Group className={"mb3"}>
-                        <Form.Label htmlFor={"upload-file"}>Upload new dataset</Form.Label>
-                        <Form.Control type="file" name="upload-file"
-                                      id={"upload-file"}
-                                      disabled={isUploading}
-                                      className={state.uploadError ? " is-invalid" : ""}
-                                      value={selectedFile}
-                                      onChange={uploadNewFile}
-                                      accept={".csv"}/>
-                        <div className={"invalid-feedback"}>
-                            {state.uploadError && state.uploadError.detail}
-                        </div>
-                        <Form.Text muted>File must be in CSV format. Required
-                            columns: biomarker, value, day. Files you upload are
-                            only accessible to you and
-                            will persist for one hour or until you close your
-                            browser,
-                            whichever is longer.</Form.Text>
-                        <div className={"d-block mt-2"}>
-                            <button className="btn btn-link p-0"
-                                    onClick={toggleShowOptions}>Advanced options
-                                <span
-                                    className="caret">{String.fromCharCode(showOptions ? 9650 : 9660)}</span>
-                            </button>
-                        </div>
-                        <div data-testid="advanced-options"
-                             className={showOptions ? "d-block" : "d-none"}>
-                            <Form.Group className={"row mb-3"}>
-                                <Form.Text muted className={"mb-3"}>
-                                    Data should be in the form of a time series
-                                    and
-                                    by default
-                                    we expect the indices of this series to be
-                                    given
-                                    in a column called 'day'.
-                                    If you want to index your time series by a
-                                    different value,
-                                    e.g. time since last exposure, you can
-                                    specify
-                                    that here.
-                                </Form.Text>
-                                <Form.Label column sm={3}>Time column
-                                    header</Form.Label>
-                                <Col sm={6}>
-                                    <Form.Control type={"text"}
-                                                  onChange={onSelectTimeColumnHeader}
-                                                  value={timeColumnHeader}/>
-                                </Col>
-                            </Form.Group>
-                            <Form.Group className={"row mb-3"}>
-                                <Form.Label column sm={3}>Time column display
-                                    name</Form.Label>
-                                <Col sm={6}>
-                                    <Form.Control type={"text"}
-                                                  onChange={onSelectTimeColumnName}
-                                                  value={timeColumnName}/>
-                                </Col>
-                            </Form.Group>
-                        </div>
-                    </Form.Group>
-                </fieldset>
-            </Form>
-        </Col>
-    </Row>
+    return <Form.Group key="choose-dataset">
+        <Form.Label htmlFor="data">Choose
+            dataset</Form.Label>
+        <Form.Select id="data" onChange={onSelectData}
+                     value={selectedDataset}>
+            {state.datasetNames.map((d: string) =>
+                <option key={d} value={d}>{d}</option>)}
+        </Form.Select>
+    </Form.Group>
 }

--- a/src/components/ChooseOrUploadDataset.tsx
+++ b/src/components/ChooseOrUploadDataset.tsx
@@ -1,0 +1,158 @@
+import React, {useContext, useEffect, useState} from 'react';
+import {Button, Col, Row} from "react-bootstrap";
+import Form from "react-bootstrap/Form";
+import {ActionType, RootContext, RootDispatchContext} from "../RootContext";
+import {api} from "../services/apiService";
+import {DataService} from "../services/dataService";
+import ChooseDataset from "./ChooseDataset";
+
+export function ChooseOrUploadDataset() {
+
+    const state = useContext(RootContext);
+    const dispatch = useContext(RootDispatchContext);
+    const apiService = api(state.language, dispatch);
+
+    useEffect(() => {
+        (new DataService(api(state.language, dispatch)))
+            .getDatasetNames();
+
+    }, [state.language, dispatch]);
+
+    useEffect(() => {
+        if (state.datasetNames.length > 0) {
+            selectDataset(state.datasetNames[0]);
+        }
+    }, [state.datasetNames]);
+
+    const go = (event: any) => {
+        event.preventDefault();
+        dispatch({type: ActionType.DATASET_SELECTED, payload: selectedDataset})
+    }
+
+    const [selectedDataset, selectDataset] = useState(state.datasetNames.length > 0 ? state.datasetNames[0] : "");
+    const [showOptions, setShowOptions] = useState(false);
+    const [timeColumnHeader, setTimeColumnHeader] = useState("day");
+    const [timeColumnName, setTimeColumnName] = useState("Day of study");
+    const [selectedFile, selectFile] = useState("");
+    const [isUploading, setIsUploading] = useState(false);
+
+    const toggleShowOptions = (event: any) => {
+        event.preventDefault();
+        setShowOptions(!showOptions);
+    }
+    const onSelectTimeColumnHeader = (e: any) => setTimeColumnHeader(e.target.value);
+    const onSelectTimeColumnName = (e: any) => setTimeColumnName(e.target.value);
+
+    const uploadNewFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        if (event.currentTarget.files?.length) {
+            dispatch({
+                type: ActionType.UPLOAD_ERROR_DISMISSED,
+                payload: null
+            });
+            const file = event.currentTarget.files[0];
+            setIsUploading(true);
+
+            const formData = new FormData();
+            formData.append('file', file);
+            formData.append('xcol', "day");
+
+            const dataService = new DataService(apiService);
+
+            const result = await dataService.uploadDataset(formData);
+
+            setIsUploading(false);
+            selectFile("");
+
+            if (result) {
+                await dataService.getDatasetNames();
+                dispatch({
+                    type: ActionType.DATASET_SELECTED,
+                    payload: result.data
+                });
+            }
+        }
+    }
+
+    return <Row className={"mt-5"}>
+        <Col xs={12} sm={{span: 6, offset: 3}}>
+            <Form>
+                <fieldset>
+                    {state.datasetNames.length > 0 &&
+                        [
+                            <ChooseDataset key={"choose"}
+                                           selectDataset={selectDataset}
+                                           selectedDataset={selectedDataset}/>,
+                            <Button key="go-btn" variant="success"
+                                    className={"w-100 mt-2 mb-3"}
+                                    type="submit" onClick={go}>Go
+                            </Button>,
+                            <h5 key="or-text"
+                                className={"text-center text-uppercase"}>or</h5>
+                        ]
+                    }
+                    <Form.Group className={"mb3"}>
+                        <Form.Label htmlFor={"upload-file"}>Upload new
+                            dataset</Form.Label>
+                        <Form.Control type="file" name="upload-file"
+                                      id={"upload-file"}
+                                      disabled={isUploading}
+                                      className={state.uploadError ? " is-invalid" : ""}
+                                      value={selectedFile}
+                                      onChange={uploadNewFile}
+                                      accept={".csv"}/>
+                        <div className={"invalid-feedback"}>
+                            {state.uploadError && state.uploadError.detail}
+                        </div>
+                        <Form.Text muted>File must be in CSV format. Required
+                            columns: biomarker, value, day. Files you upload are
+                            only accessible to you and
+                            will persist for one hour or until you close your
+                            browser,
+                            whichever is longer.</Form.Text>
+                        <div className={"d-block mt-2"}>
+                            <button className="btn btn-link p-0"
+                                    onClick={toggleShowOptions}>Advanced options
+                                <span
+                                    className="caret">{String.fromCharCode(showOptions ? 9650 : 9660)}</span>
+                            </button>
+                        </div>
+                        <div data-testid="advanced-options"
+                             className={showOptions ? "d-block" : "d-none"}>
+                            <Form.Group className={"row mb-3"}>
+                                <Form.Text muted className={"mb-3"}>
+                                    Data should be in the form of a time series
+                                    and
+                                    by default
+                                    we expect the indices of this series to be
+                                    given
+                                    in a column called 'day'.
+                                    If you want to index your time series by a
+                                    different value,
+                                    e.g. time since last exposure, you can
+                                    specify
+                                    that here.
+                                </Form.Text>
+                                <Form.Label column sm={3}>Time column
+                                    header</Form.Label>
+                                <Col sm={6}>
+                                    <Form.Control type={"text"}
+                                                  onChange={onSelectTimeColumnHeader}
+                                                  value={timeColumnHeader}/>
+                                </Col>
+                            </Form.Group>
+                            <Form.Group className={"row mb-3"}>
+                                <Form.Label column sm={3}>Time column display
+                                    name</Form.Label>
+                                <Col sm={6}>
+                                    <Form.Control type={"text"}
+                                                  onChange={onSelectTimeColumnName}
+                                                  value={timeColumnName}/>
+                                </Col>
+                            </Form.Group>
+                        </div>
+                    </Form.Group>
+                </fieldset>
+            </Form>
+        </Col>
+    </Row>
+}

--- a/src/components/ExploreDataset.tsx
+++ b/src/components/ExploreDataset.tsx
@@ -9,7 +9,8 @@ export function ExploreDataset() {
 
     const state = useContext(RootContext);
 
-    const facetVariables = state.selectedCovariates
+    const facetVariables = state.datasetSettings[state.selectedDataset]
+        .covariateSettings
         .filter(v => v.display === "facet");
 
     const allFacetLevels = facetVariables.map(f => f.levels);

--- a/src/components/LinePlot.tsx
+++ b/src/components/LinePlot.tsx
@@ -45,13 +45,13 @@ export default function LinePlot({
     useEffect(() => {
         dataService(state.language, dispatch)
             .getDataSeries(state.selectedDataset,
-                biomarker, facetDefinition, state.selectedCovariates)
+                biomarker, facetDefinition, state.datasetSettings[state.selectedDataset].covariateSettings)
             .then(data => {
                 if (data && data.data) {
                     setSeries(data.data)
                 }
             });
-    }, [state.language, dispatch, state.selectedDataset, biomarker, facetDefinition, state.selectedCovariates]);
+    }, [state.language, dispatch, state.selectedDataset, biomarker, facetDefinition, state.datasetSettings]);
 
     let series: any[] = [];
 

--- a/src/components/SelectedCovariate.tsx
+++ b/src/components/SelectedCovariate.tsx
@@ -1,10 +1,10 @@
 import {Button, Col, Form, Row} from "react-bootstrap";
 import React, {useContext} from "react";
 import {ActionType, RootDispatchContext} from "../RootContext";
-import {SelectedCovariate} from "../types";
+import {CovariateSettings} from "../types";
 
 
-export default function SelectedCovariateOption({covariate}: { covariate: SelectedCovariate, key: string }) {
+export default function SelectedCovariate({covariate}: { covariate: CovariateSettings, key: string }) {
 
     const dispatch = useContext(RootDispatchContext);
 

--- a/src/components/SideBar.tsx
+++ b/src/components/SideBar.tsx
@@ -3,21 +3,24 @@ import {Col, Row} from "react-bootstrap";
 import React, {useContext} from "react";
 import {ActionType, RootContext, RootDispatchContext} from "../RootContext";
 import CovariateOptions from "./CovariateOptions";
-import SelectedCovariateOption from "./SelectedCovariateOption";
+import SelectedCovariate from "./SelectedCovariate";
+import ChooseDataset from "./ChooseDataset";
 
 export default function SideBar() {
 
     const state = useContext(RootContext);
     const dispatch = useContext(RootDispatchContext);
 
-    const onSelectData = (event: any) => {
+    const selectDataset = (name: string) => {
         dispatch({
             type: ActionType.DATASET_SELECTED,
-            payload: event.target.value
+            payload: name
         })
     }
 
-    const selectedCovariates = state.selectedCovariates.map(v => v.name);
+    const selectedCovariates = state.datasetSettings[state.selectedDataset]
+        .covariateSettings
+        .map(v => v.name);
 
     const availableCovariates = state.datasetMetadata?.variables
         .filter(v => selectedCovariates.indexOf(v.name) === -1) ?? [];
@@ -26,15 +29,9 @@ export default function SideBar() {
                 data-testid="sidebar">
         <Form method="post">
             <fieldset>
-                <Form.Group className="mb-3">
-                    <Form.Label htmlFor="data">Dataset</Form.Label>
-                    <Form.Select id="data" onChange={onSelectData}
-                                 value={state.selectedDataset}>
-                        {state.datasetNames.map(d =>
-                            <option key={d} value={d}>{d}</option>)}
-                    </Form.Select>
-                </Form.Group>
-                <Row className={"mb-3"}>
+                <ChooseDataset selectedDataset={state.selectedDataset}
+                               selectDataset={selectDataset}/>
+                <Row className={"mb-3 mt-3"}>
                     <Col>
                         Detected biomarkers <br/><span
                         className={"text-secondary"}>{state.datasetMetadata?.biomarkers.join(", ")}</span>
@@ -47,10 +44,12 @@ export default function SideBar() {
                     </Form.Group>
                 }
                 <Form.Group className="mb-3">
-                    {state.selectedCovariates.map(v =>
-                        <SelectedCovariateOption
-                            key={v.name}
-                            covariate={v}/>)}
+                    {state.datasetSettings[state.selectedDataset]
+                        .covariateSettings
+                        .map(v =>
+                            <SelectedCovariate
+                                key={v.name}
+                                covariate={v}/>)}
                 </Form.Group>
             </fieldset>
         </Form>

--- a/src/hooks/usePersistedState.ts
+++ b/src/hooks/usePersistedState.ts
@@ -9,6 +9,7 @@ export default function usePersistedState<T>(key: string, defaultValue: T) {
     }, [key]);
 
     const setWithLocalStorage = (nextState: T) => {
+        localStorage.setItem(key, nextState as string);
         setState(nextState);
     };
 

--- a/src/reducers/datasetReducer.ts
+++ b/src/reducers/datasetReducer.ts
@@ -1,0 +1,47 @@
+import {AppState, DatasetSettings} from "../types";
+import {ActionType, RootAction} from "../RootContext";
+
+export const datasetReducer = (state: AppState, action: RootAction): AppState => {
+    switch (action.type) {
+        case ActionType.DATASET_SELECTED:
+            return selectDataset(state, action)
+        case ActionType.DATASET_METADATA_FETCHED:
+            return {...state, datasetMetadata: action.payload}
+        case ActionType.SELECT_COVARIATE:
+            return selectCovariate(state, action)
+        case ActionType.UNSELECT_COVARIATE:
+            return unselectCovariate(state, action)
+        default:
+            return state
+    }
+}
+
+const datasetSettings = (): DatasetSettings => ({
+    covariateSettings: [],
+    scale: "natural"
+})
+
+const selectDataset = (state: AppState, action: RootAction): AppState => {
+    const newState = {...state}
+    if (!newState.datasetSettings[action.payload]) {
+        newState.datasetSettings[action.payload] = datasetSettings()
+    }
+    newState.selectedDataset = action.payload
+    return newState
+}
+
+const selectCovariate = (state: AppState, action: RootAction): AppState => {
+    const newState = {...state}
+    const settings = newState.datasetSettings[state.selectedDataset].covariateSettings
+    if (settings.indexOf(action.payload) === -1) {
+        settings.push(action.payload)
+    }
+    return newState
+}
+
+const unselectCovariate = (state: AppState, action: RootAction) => {
+    const newState = {...state}
+    const settings = newState.datasetSettings[state.selectedDataset].covariateSettings
+    newState.datasetSettings[state.selectedDataset].covariateSettings = settings.filter(v => v.name !== action.payload)
+    return newState
+}

--- a/src/reducers/rootReducer.ts
+++ b/src/reducers/rootReducer.ts
@@ -1,0 +1,21 @@
+import {AppState} from "../types";
+import {ActionType, RootAction} from "../RootContext";
+import {datasetReducer} from "./datasetReducer";
+
+export const rootReducer = (state: AppState, action: RootAction): AppState => {
+    console.log(action.type);
+    switch (action.type) {
+        case ActionType.ERROR_ADDED:
+            return {...state, genericError: action.payload}
+        case ActionType.ERROR_DISMISSED:
+            return {...state, genericError: null}
+        case ActionType.UPLOAD_ERROR_ADDED:
+            return {...state, uploadError: action.payload}
+        case ActionType.UPLOAD_ERROR_DISMISSED:
+            return {...state, uploadError: null}
+        case ActionType.DATASET_NAMES_FETCHED:
+            return {...state, datasetNames: action.payload}
+        default:
+            return datasetReducer(state, action)
+    }
+}

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -7,7 +7,7 @@ import {
     UploadResult
 } from "../generated";
 import {
-    GenericResponse, SelectedCovariate,
+    GenericResponse, CovariateSettings,
 } from "../types";
 import {Dispatch} from "react";
 
@@ -50,7 +50,7 @@ export class DataService {
     async getDataSeries(selectedDataset: string,
                         biomarker: string,
                         facetDefinition: string,
-                        selectedCovariates: SelectedCovariate[]) {
+                        selectedCovariates: CovariateSettings[]) {
 
 
         const traces = selectedCovariates

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,15 +19,20 @@ export interface Dict<T> {
     [index: string]: T
 }
 
-export interface SelectedCovariate extends Variable {
+export interface CovariateSettings extends Variable {
     display: PlotDisplay
+}
+
+export interface DatasetSettings {
+    covariateSettings: CovariateSettings[]
+    scale: "log" | "natural" | "log2"
 }
 
 export interface AppState {
     datasetNames: DatasetNames
     datasetMetadata: DatasetMetadata | null
     selectedDataset: string
-    selectedCovariates: SelectedCovariate[]
+    datasetSettings: Dict<DatasetSettings>
     uploadError: ErrorDetail | null
     genericError: ErrorDetail | null
     language: string

--- a/test/components/ChooseDataset.test.tsx
+++ b/test/components/ChooseDataset.test.tsx
@@ -1,4 +1,4 @@
-import {ChooseDataset} from "../../src/components/ChooseDataset";
+import {ChooseOrUploadDataset} from "../../src/components/ChooseOrUploadDataset";
 import {
     ActionType,
     RootContext,
@@ -9,7 +9,7 @@ import {mockAppState, mockAxios, mockSuccess} from "../mocks";
 import {act} from "react";
 import {userEvent} from "@testing-library/user-event";
 
-describe("<ChooseDataset/>", () => {
+describe("<ChooseOrUploadDataset/>", () => {
 
     beforeEach(() => {
         mockAxios.reset();
@@ -24,7 +24,7 @@ describe("<ChooseDataset/>", () => {
 
         act(() => render(<RootContext.Provider value={state}>
             <RootDispatchContext.Provider
-                value={dispatch}><ChooseDataset/>
+                value={dispatch}><ChooseOrUploadDataset/>
             </RootDispatchContext.Provider>
         </RootContext.Provider>));
 
@@ -47,7 +47,7 @@ describe("<ChooseDataset/>", () => {
 
         act(() => render(<RootContext.Provider value={state}>
             <RootDispatchContext.Provider
-                value={dispatch}><ChooseDataset/>
+                value={dispatch}><ChooseOrUploadDataset/>
             </RootDispatchContext.Provider>
         </RootContext.Provider>));
 
@@ -69,7 +69,7 @@ describe("<ChooseDataset/>", () => {
 
         act(() => render(<RootContext.Provider value={state}>
             <RootDispatchContext.Provider
-                value={dispatch}><ChooseDataset/>
+                value={dispatch}><ChooseOrUploadDataset/>
             </RootDispatchContext.Provider>
         </RootContext.Provider>));
 
@@ -89,7 +89,7 @@ describe("<ChooseDataset/>", () => {
 
         act(() => render(<RootContext.Provider value={state}>
             <RootDispatchContext.Provider
-                value={dispatch}><ChooseDataset/>
+                value={dispatch}><ChooseOrUploadDataset/>
             </RootDispatchContext.Provider>
         </RootContext.Provider>));
 
@@ -117,7 +117,7 @@ describe("<ChooseDataset/>", () => {
 
         act(() => render(<RootContext.Provider value={state}>
             <RootDispatchContext.Provider
-                value={dispatch}><ChooseDataset/>
+                value={dispatch}><ChooseOrUploadDataset/>
             </RootDispatchContext.Provider>
         </RootContext.Provider>));
 
@@ -145,7 +145,7 @@ describe("<ChooseDataset/>", () => {
 
         act(() => render(<RootContext.Provider value={state}>
             <RootDispatchContext.Provider
-                value={dispatch}><ChooseDataset/>
+                value={dispatch}><ChooseOrUploadDataset/>
             </RootDispatchContext.Provider>
         </RootContext.Provider>));
 

--- a/test/components/ExploreDataset.test.tsx
+++ b/test/components/ExploreDataset.test.tsx
@@ -1,7 +1,10 @@
 import {
     mockAppState,
     mockAxios,
-    mockDatasetMetadata, mockSelectedCovariate, mockSeriesData,
+    mockDatasetMetadata,
+    mockDatasetSettings,
+    mockSelectedCovariate,
+    mockSeriesData,
     mockSuccess
 } from "../mocks";
 import {render, screen} from "@testing-library/react";
@@ -28,6 +31,8 @@ describe("<ExploreDataset/>", () => {
                 .reply(200, mockSuccess(mockSeriesData()));
 
             const state = mockAppState({
+                selectedDataset: "d1",
+                datasetSettings: {"d1": mockDatasetSettings()},
                 datasetMetadata: mockDatasetMetadata({
                     biomarkers: ["ab", "ba"]
                 })
@@ -52,17 +57,22 @@ describe("<ExploreDataset/>", () => {
                     datasetMetadata: mockDatasetMetadata({
                         biomarkers: ["ab", "ba"]
                     }),
-                    selectedCovariates: [
-                        mockSelectedCovariate({
-                            display: "facet",
-                            name: "age",
-                            levels: ["0-5", "5+"]
-                        }),
-                        mockSelectedCovariate({
-                            name: "sex",
-                            display: "trace"
+                    selectedDataset: "d1",
+                    datasetSettings: {
+                        "d1": mockDatasetSettings({
+                            covariateSettings: [
+                                mockSelectedCovariate({
+                                    display: "facet",
+                                    name: "age",
+                                    levels: ["0-5", "5+"]
+                                }),
+                                mockSelectedCovariate({
+                                    name: "sex",
+                                    display: "trace"
+                                })
+                            ]
                         })
-                    ]
+                    }
                 });
                 await act(() => render(<RootContext.Provider value={state}>
                     <ExploreDataset/>

--- a/test/components/SelectedCovariate.test.tsx
+++ b/test/components/SelectedCovariate.test.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import {fireEvent, render, screen} from "@testing-library/react";
 import {mockSelectedCovariate} from "../mocks";
 import {ActionType, RootDispatchContext} from "../../src/RootContext";
-import SelectedCovariateOption
-    from "../../src/components/SelectedCovariateOption";
+import SelectedCovariate
+    from "../../src/components/SelectedCovariate";
 
-describe("<SelectedCovariateOption />", () => {
+describe("<SelectedCovariate />", () => {
 
     const covariate = mockSelectedCovariate({
         name: "age",
@@ -17,7 +17,7 @@ describe("<SelectedCovariateOption />", () => {
         const dispatch = jest.fn();
         const {container} = render(
             <RootDispatchContext.Provider value={dispatch}>
-                <SelectedCovariateOption covariate={covariate} key={"1"}/>
+                <SelectedCovariate covariate={covariate} key={"1"}/>
             </RootDispatchContext.Provider>);
         expect(container.textContent).toContain("age");
         expect(container.textContent).toContain("trace");
@@ -27,8 +27,8 @@ describe("<SelectedCovariateOption />", () => {
         const dispatch = jest.fn();
         render(
             <RootDispatchContext.Provider
-                value={dispatch}><SelectedCovariateOption covariate={covariate}
-                                                          key={"1"}/>
+                value={dispatch}><SelectedCovariate covariate={covariate}
+                                                    key={"1"}/>
             </RootDispatchContext.Provider>);
         const closeButton = screen.getByRole("close");
 

--- a/test/components/SideBar.test.tsx
+++ b/test/components/SideBar.test.tsx
@@ -2,7 +2,7 @@ import {render, screen} from "@testing-library/react";
 import SideBar from "../../src/components/SideBar";
 import {
     mockAppState,
-    mockDatasetMetadata,
+    mockDatasetMetadata, mockDatasetSettings,
     mockSelectedCovariate,
     mockVariable
 } from "../mocks";
@@ -24,9 +24,14 @@ describe("<SideBar />", () => {
                     mockVariable({name: "c"}),
                 ]
             }),
-            selectedCovariates: [
-                mockSelectedCovariate({name: "a"})
-            ]
+            selectedDataset: "d1",
+            datasetSettings: {
+                "d1": mockDatasetSettings({
+                    covariateSettings: [
+                        mockSelectedCovariate({name: "a"})
+                    ]
+                })
+            }
         });
         const {container} = render(<RootContext.Provider value={state}>
             <SideBar></SideBar>
@@ -45,7 +50,8 @@ describe("<SideBar />", () => {
             datasetMetadata: mockDatasetMetadata({
                 variables: []
             }),
-            selectedCovariates: []
+            selectedDataset: "d1",
+            datasetSettings: {"d1": mockDatasetSettings()}
         });
         const {container} = render(<RootContext.Provider value={state}>
             <SideBar></SideBar>
@@ -58,7 +64,9 @@ describe("<SideBar />", () => {
         const state = mockAppState({
             datasetMetadata: mockDatasetMetadata({
                 biomarkers: ["ab", "ba"]
-            })
+            }),
+            selectedDataset: "d1",
+            datasetSettings: {"d1": mockDatasetSettings()}
         });
         const {container} = render(<RootContext.Provider value={state}>
             <SideBar></SideBar>
@@ -70,7 +78,8 @@ describe("<SideBar />", () => {
     test("user can change dataset", async () => {
         const state = mockAppState({
             datasetNames: ["d1", "d2"],
-            selectedDataset: "d1"
+            selectedDataset: "d1",
+            datasetSettings: {"d1": mockDatasetSettings()}
         });
         const dispatch = jest.fn();
         render(

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -3,7 +3,7 @@ import MockAdapter from "axios-mock-adapter";
 import {
     AppState,
     ResponseSuccess,
-    SelectedCovariate
+    CovariateSettings, DatasetSettings
 } from "../src/types";
 import {
     DataSeries,
@@ -18,7 +18,7 @@ export function mockAppState(state: Partial<AppState> = {}): AppState {
         datasetNames: [],
         datasetMetadata: null,
         selectedDataset: "",
-        selectedCovariates: [],
+        datasetSettings: {},
         uploadError: null,
         genericError: null,
         language: "en",
@@ -39,6 +39,14 @@ export function mockDatasetMetadata(datasetMetadata: Partial<DatasetMetadata> = 
     }
 }
 
+export function mockDatasetSettings(settings: Partial<DatasetSettings> = {}): DatasetSettings {
+    return {
+        covariateSettings: [],
+        scale: "natural",
+        ...settings
+    }
+}
+
 export function mockVariable(variable: Partial<Variable> = {}): Variable {
     return {
         name: "sex",
@@ -47,7 +55,7 @@ export function mockVariable(variable: Partial<Variable> = {}): Variable {
     }
 }
 
-export function mockSelectedCovariate(variable: Partial<SelectedCovariate> = {}): SelectedCovariate {
+export function mockSelectedCovariate(variable: Partial<CovariateSettings> = {}): CovariateSettings {
     return {
         name: "sex",
         levels: ["F", "M"],
@@ -56,7 +64,7 @@ export function mockSelectedCovariate(variable: Partial<SelectedCovariate> = {})
     }
 }
 
-export function mockCovariate(variable: Partial<SelectedCovariate> = {}): SelectedCovariate {
+export function mockCovariate(variable: Partial<CovariateSettings> = {}): CovariateSettings {
     return {
         name: "c1",
         levels: ["1", "2"],

--- a/test/rootReducer.test.ts
+++ b/test/rootReducer.test.ts
@@ -1,12 +1,22 @@
-import {mockAppState, mockCovariate, mockDatasetMetadata, mockDatasetNames, mockError} from "./mocks";
-import {ActionType, rootReducer} from "../src/RootContext";
+import {
+    mockAppState,
+    mockCovariate,
+    mockDatasetMetadata,
+    mockDatasetNames, mockDatasetSettings,
+    mockError
+} from "./mocks";
+import {ActionType} from "../src/RootContext";
+import {rootReducer} from "../src/reducers/rootReducer";
 
 describe("rootReducer", () => {
 
     it("should add generic error on ERROR_ADDED", () => {
         const state = mockAppState();
         const newState = rootReducer(state,
-            {type: ActionType.ERROR_ADDED, payload: mockError("custom message")});
+            {
+                type: ActionType.ERROR_ADDED,
+                payload: mockError("custom message")
+            });
         expect(newState.genericError).toEqual(mockError("custom message"));
     });
 
@@ -20,7 +30,10 @@ describe("rootReducer", () => {
     it("should add upload error on UPLOAD_ERROR_ADDED", () => {
         const state = mockAppState({uploadError: null});
         const newState = rootReducer(state,
-            {type: ActionType.UPLOAD_ERROR_ADDED, payload: mockError("custom message")});
+            {
+                type: ActionType.UPLOAD_ERROR_ADDED,
+                payload: mockError("custom message")
+            });
         expect(newState.uploadError).toEqual(mockError("custom message"));
     });
 
@@ -34,38 +47,58 @@ describe("rootReducer", () => {
     it("should add datasets on DATASET_NAMES_FETCHED", () => {
         const state = mockAppState();
         const newState = rootReducer(state,
-            {type: ActionType.DATASET_NAMES_FETCHED, payload: mockDatasetNames()});
+            {
+                type: ActionType.DATASET_NAMES_FETCHED,
+                payload: mockDatasetNames()
+            });
         expect(newState.datasetNames).toEqual(mockDatasetNames());
     });
 
     it("should add dataset metadata on DATASET_METADATA_FETCHED", () => {
         const state = mockAppState();
         const newState = rootReducer(state,
-            {type: ActionType.DATASET_METADATA_FETCHED, payload: mockDatasetMetadata()});
+            {
+                type: ActionType.DATASET_METADATA_FETCHED,
+                payload: mockDatasetMetadata()
+            });
         expect(newState.datasetMetadata).toEqual(mockDatasetMetadata());
     });
 
-    it("should select dataset on DATASET_SELECTED", () => {
+    it("should select dataset and add key to dataset settings on DATASET_SELECTED", () => {
         const state = mockAppState();
         const newState = rootReducer(state,
             {type: ActionType.DATASET_SELECTED, payload: "d1"});
         expect(newState.selectedDataset).toBe("d1");
+        expect(newState.datasetSettings["d1"].covariateSettings).toEqual([]);
+        expect(newState.datasetSettings["d1"].scale).toEqual("natural");
+
     });
 
     it("should add covariate on SELECT_COVARIATE", () => {
-        const state = mockAppState();
+        const state = mockAppState({
+            selectedDataset: "d1",
+            datasetSettings: {"d1": mockDatasetSettings()}
+        });
         const newState = rootReducer(state,
-            {type: ActionType.SELECT_COVARIATE, payload: mockCovariate({name: "c1"})});
-        expect(newState.selectedCovariates.length).toBe(1);
-        expect(newState.selectedCovariates[0]).toEqual(mockCovariate({name: "c1"}));
+            {
+                type: ActionType.SELECT_COVARIATE,
+                payload: mockCovariate({name: "c1"})
+            });
+        expect(newState.datasetSettings["d1"].covariateSettings.length).toBe(1);
+        expect(newState.datasetSettings["d1"].covariateSettings[0]).toEqual(mockCovariate({name: "c1"}));
     });
 
     it("should remove covariate on UNSELECT_COVARIATE", () => {
         const state = mockAppState({
-            selectedCovariates: [mockCovariate({name: "c1"})]
+            selectedDataset: "d1",
+            datasetSettings: {
+                "d1": mockDatasetSettings({
+                    covariateSettings: [mockCovariate({name: "c1"})]
+                })
+            }
         });
         const newState = rootReducer(state,
             {type: ActionType.UNSELECT_COVARIATE, payload: "c1"});
-        expect(newState.selectedCovariates.length).toBe(0);
+        expect(newState.datasetSettings["d1"].covariateSettings.length).toBe(0);
     });
 });


### PR DESCRIPTION
* Ahead of adding configurable data scale, refactors root state to include a dictionary of dataset settings
* Pulls out reducers into their own files
* Also factors out `ChooseDataset` as a common component, to be used in the sidebar as well as the index page.