### PR TITLE
use plot title as filename

### DIFF
--- a/src/components/LinePlot.tsx
+++ b/src/components/LinePlot.tsx
@@ -3,6 +3,7 @@ import Plot from 'react-plotly.js';
 import {RootContext, RootDispatchContext} from "../RootContext";
 import {DataSeries} from "../generated";
 import {dataService} from "../services/dataService";
+import {toFilename} from "../services/plotUtils";
 
 interface Props {
     biomarker: string
@@ -52,9 +53,7 @@ export default function LinePlot({
 
             if (result && result.data) {
                 setSeries(result.data)
-            }
-
-            else {
+            } else {
                 setSeries(null)
             }
         }
@@ -89,18 +88,28 @@ export default function LinePlot({
         series = []
     }
 
+    let title = biomarker;
+    if (facetDefinition) {
+        title += " " + facetDefinition
+    }
+
     return <Plot
         data={series}
         layout={{
-            title: biomarker + " " + facetDefinition,
+            title: title,
             legend: {xanchor: 'center', orientation: 'v'},
-            paper_bgcolor: "rgba(255,255,255, 0)",
             xaxis: {
                 title: {
                     text: state.datasetMetadata?.xcol
                 }
+            },
+            yaxis: {
+                title: {
+                    text: scale === "natural" ? "value" : `${scale} value`
+                }
             }
         }}
+        config={{toImageButtonOptions: {filename: toFilename(title)}}}
         useResizeHandler={true}
         style={{minWidth: "400px", width: "100%", height: "500"}}
     />

--- a/src/services/plotUtils.ts
+++ b/src/services/plotUtils.ts
@@ -7,5 +7,6 @@ export const calculateFacets = (first: string[], next: string[], ...rest: string
 
 export const toFilename = (title: string) => title
     .toLowerCase()
+    .replaceAll(/\W+/g, " ")
     .trim()
-    .replaceAll(/\W+/g, "_");
+    .replaceAll(/\s+/g, "_")

--- a/src/services/plotUtils.ts
+++ b/src/services/plotUtils.ts
@@ -4,3 +4,8 @@ export const calculateFacets = (first: string[], next: string[], ...rest: string
     if (rest.length) next = calculateFacets(next, rest.shift()!!, ...rest);
     return first.flatMap(a => next.map(b => [a, b].flat()));
 }
+
+export const toFilename = (title: string) => title
+    .toLowerCase()
+    .trim()
+    .replaceAll(/\W+/g, "_");

--- a/test/components/App.test.tsx
+++ b/test/components/App.test.tsx
@@ -42,6 +42,6 @@ describe("<App />", () => {
         await userEvent.click(go);
 
         const biomarkers = await screen.findByText("Detected biomarkers");
-        expect(biomarkers.nextSibling?.textContent).toBe("ab");
+        expect(biomarkers.parentNode?.textContent).toBe("Detected biomarkers ab");
     });
 });

--- a/test/components/App.test.tsx
+++ b/test/components/App.test.tsx
@@ -41,6 +41,7 @@ describe("<App />", () => {
         const go = await screen.findByText("Go");
         await userEvent.click(go);
 
-        await screen.findByText("Detected biomarkers");
+        const biomarkers = await screen.findByText("Detected biomarkers");
+        expect(biomarkers.nextSibling?.textContent).toBe("ab");
     });
 });

--- a/test/components/LinePlot.test.tsx
+++ b/test/components/LinePlot.test.tsx
@@ -61,8 +61,7 @@ describe("<LinePlot />", () => {
             .toBeCalledTimes(2));
 
         const plot = Plot as Mock
-        expect(plot.mock.calls[1][0]).toEqual({
-            data: [
+        expect(plot.mock.calls[1][0].data).toEqual([
                 {
                     legendgroup: "all",
                     line: {
@@ -91,27 +90,7 @@ describe("<LinePlot />", () => {
                     type: "scatter",
                     x: [1, 2],
                     y: [3, 4]
-                }],
-            layout: {
-                legend: {
-                    orientation: "v",
-                    xanchor: "center"
-                },
-                paper_bgcolor: "rgba(255,255,255, 0)",
-                title: "ab ",
-                xaxis: {
-                    title: {
-                        text: "day"
-                    }
-                }
-            },
-            style: {
-                height: "500",
-                minWidth: "400px",
-                width: "100%"
-            },
-            useResizeHandler: true
-        })
+                }])
     });
 
     test("requests data for given facet variables", async () => {

--- a/test/services/plotUtils.test.ts
+++ b/test/services/plotUtils.test.ts
@@ -31,6 +31,7 @@ describe("plotUtils", () => {
     it("can generate snake case filename", () => {
         expect(toFilename("ab_units sex:F")).toBe("ab_units_sex_f")
         expect(toFilename("ab_units  sex:F")).toBe("ab_units_sex_f")
+        expect(toFilename("ab_units  sex:F+age:5+")).toBe("ab_units_sex_f_age_5")
         expect(toFilename("ab_units  ")).toBe("ab_units")
         expect(toFilename("ab_units")).toBe("ab_units")
         expect(toFilename("ABunits")).toBe("abunits")

--- a/test/services/plotUtils.test.ts
+++ b/test/services/plotUtils.test.ts
@@ -1,7 +1,8 @@
-import {calculateFacets} from "../../src/services/plotUtils";
+import {calculateFacets, toFilename} from "../../src/services/plotUtils";
 import {Variable} from "../../src/generated";
 
 describe("plotUtils", () => {
+
     it("Can calculate facets", () => {
         const facetVariables: Variable[] = [
             {
@@ -25,5 +26,13 @@ describe("plotUtils", () => {
         expect(result[5]).toEqual(["M", "1", "ba"])
         expect(result[6]).toEqual(["M", "2", "ab"])
         expect(result[7]).toEqual(["M", "2", "ba"])
+    })
+
+    it("can generate snake case filename", () => {
+        expect(toFilename("ab_units sex:F")).toBe("ab_units_sex_f")
+        expect(toFilename("ab_units  sex:F")).toBe("ab_units_sex_f")
+        expect(toFilename("ab_units  ")).toBe("ab_units")
+        expect(toFilename("ab_units")).toBe("ab_units")
+        expect(toFilename("ABunits")).toBe("abunits")
     })
 });


### PR DESCRIPTION
When downloading plotly graphs as pngs, the filename should be the plot title converted to snake case.