### PR TITLE
i31 add router and faq

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,17 @@
+name: 🗑 Cleanup session files
+# Hitting the API checks for inactive sessions and cleans up any orphaned files.
+# This action runs on an hourly schedule to make sure this cleanup happens at least
+# once an hour.
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 * * * *'
+
+jobs:
+  cleanup:
+    name: 🗑 Cleanup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup
+        run: curl https://seroviz.seroanalytics.org/api/

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "seroviz",
       "version": "0.1.0",
+      "license": "GPL-3.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.17.0",
         "@types/jest": "^27.5.2",
@@ -37,6 +38,7 @@
         "json-schema-to-typescript": "^15.0.0",
         "mime-types": "^2.1.35",
         "react-plotly.js": "^2.6.0",
+        "react-router-dom": "^7.0.2",
         "ts-jest": "^29.2.4",
         "ts-node": "^10.9.2"
       }
@@ -5060,6 +5062,12 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "8.56.11",
@@ -20077,6 +20085,55 @@
         "react": ">= 16.3"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.0.2.tgz",
+      "integrity": "sha512-m5AcPfTRUcjwmhBzOJGEl6Y7+Crqyju0+TgTQxoS4SO+BkWbhOrcfZNq6wSWdl2BBbJbsAoBUb8ZacOFT+/JlA==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.0.2.tgz",
+      "integrity": "sha512-VJOQ+CDWFDGaWdrG12Nl+d7yHtLaurNgAQZVgaIy7/Xd+DojgmYLosFfZdGz1wpxmjJIAkAMVTKWcvkx1oggAw==",
+      "dev": true,
+      "dependencies": {
+        "react-router": "7.0.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -22435,6 +22492,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "dev": true
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -24037,6 +24100,12 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "dev": true
     },
     "node_modules/type": {
       "version": "2.7.3",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "json-schema-to-typescript": "^15.0.0",
     "mime-types": "^2.1.35",
     "react-plotly.js": "^2.6.0",
+    "react-router-dom": "^7.0.2",
     "ts-jest": "^29.2.4",
     "ts-node": "^10.9.2"
   },

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -1,0 +1,105 @@
+import React, {useReducer} from 'react';
+import {Col, Container, Row} from "react-bootstrap";
+import TopNav from "./TopNav";
+import usePersistedState from "../hooks/usePersistedState";
+import {
+    initialState,
+    RootContext,
+    RootDispatchContext
+} from "../RootContext";
+import {rootReducer} from "../reducers/rootReducer";
+
+export default function FAQ() {
+
+    const [theme, setTheme] = usePersistedState<string>("theme", "dark");
+    const [state, dispatch] = useReducer(rootReducer, initialState);
+
+    return <RootContext.Provider value={state}>
+        <RootDispatchContext.Provider value={dispatch}>
+            <TopNav theme={theme as string}
+                    setTheme={setTheme as (newState: string) => void}></TopNav>
+            <Container fluid>
+                <Row className={"mt-5"}>
+                    <Col xs={12} sm={{span: 8, offset: 2}}>
+                        <h1>FAQ</h1>
+                        <ul>
+                            <li className={"fw-bold mt-2"}>
+                                What format does my data need to be in?
+                            </li>
+                            <p>Data should be a CSV containing an absolute or
+                                relative time series of biomarker values, in
+                                long-format.
+                                Required columns
+                                are <i>biomarker</i> and <i>value</i>,
+                                plus a column containing a time variable, the
+                                name of which is configurable but defaults
+                                to <i>day</i>. Arbitrarily many extra columns
+                                are allowed and will be made available to
+                                disaggregate by.</p>
+                            <li className={"fw-bold mt-2"}>
+                                What is the difference between "serological
+                                surveillance" and "post-exposure" data?
+                            </li>
+                            <p>
+                                By "serological surveillance" we mean time
+                                series
+                                data where the time variable is based on
+                                absolute
+                                calendar date; for example, a study that
+                                monitors a population level biomarker over time.
+                                The time variable here might be day of study, or
+                                calendar date.</p>
+                            <p>
+                                By "post-exposure" data we mean a relative time
+                                series,
+                                where biomarker levels are measured for each
+                                individual
+                                relative to a known exposure (vaccination or
+                                infection). The time variable here would be time
+                                since exposure.
+                            </p>
+                            <li className={"fw-bold mt-2"}>
+                                Where is my data kept? Is it secure?
+                            </li>
+                            <p>SeroViz is deployed to Digital Ocean's App
+                                Platform; access to the remote server is
+                                limited to app maintainers and secured via 2fa.
+                                You can read more about Digital
+                                Ocean's infrastructure security <a
+                                    href={"https://www.digitalocean.com/security/infrastructure-security"}>here</a>.
+                            </p>
+                            <p>Files are temporarily uploaded to the remote
+                                server
+                                under a unique session id, and will persist as
+                                long as your keep your browser open.
+                                When you close your browser all session cookies
+                                will be deleted, and remote files associated
+                                with inactive sessions are deleted every hour.
+                            </p>
+                            <p>Or, to force your session and all associated
+                                files to be deleted immediately, you can click
+                                the "End session" link in the top-right
+                                corner.
+                            </p>
+                            <li className={"fw-bold mt-2"}>
+                                Who funded this project? Who maintains it?
+                            </li>
+                            This project was funded by the Wellcome Trust. It
+                            was built
+                            by <a href={"https://github.com/hillalex/"}>Alex
+                            Hill</a> and is maintained by <a
+                            href={"https://github.com/dchodge/"}>David
+                            Hodgson</a>.
+                            <li className={"fw-bold mt-2"}>
+                                How do I request new features?
+                            </li>
+                            Please raise a GitHub issue on the <a
+                            href={"https://github.com/seroanalytics/seroviz"}>seroviz
+                            repo</a>.
+                        </ul>
+                    </Col>
+                </Row>
+            </Container>
+        </RootDispatchContext.Provider>
+    </RootContext.Provider>
+}

--- a/src/components/NoPage.tsx
+++ b/src/components/NoPage.tsx
@@ -1,0 +1,26 @@
+import React, {useReducer} from 'react';
+import {Container} from "react-bootstrap";
+import TopNav from "./TopNav";
+import usePersistedState from "../hooks/usePersistedState";
+import {
+    initialState,
+    RootContext,
+    RootDispatchContext
+} from "../RootContext";
+import {rootReducer} from "../reducers/rootReducer";
+
+export default function NoPage() {
+
+    const [theme, setTheme] = usePersistedState<string>("theme", "dark");
+    const [state, dispatch] = useReducer(rootReducer, initialState);
+
+    return <RootContext.Provider value={state}>
+        <RootDispatchContext.Provider value={dispatch}>
+            <TopNav theme={theme as string}
+                    setTheme={setTheme as (newState: string) => void}></TopNav>
+            <Container fluid>
+                <h1>Page not found</h1>
+            </Container>
+        </RootDispatchContext.Provider>
+    </RootContext.Provider>
+}

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -39,6 +39,7 @@ export default function TopNav({
             <Navbar.Collapse id="basic-navbar-nav">
                 <Nav className="me-auto">
                     <Nav.Link href="/">Manage datasets</Nav.Link>
+                    <Nav.Link href="/faq">FAQ</Nav.Link>
                     <Nav.Link href="/docs">Docs</Nav.Link>
                 </Nav>
             </Navbar.Collapse>

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -40,7 +40,6 @@ export default function TopNav({
                 <Nav className="me-auto">
                     <Nav.Link href="/">Manage datasets</Nav.Link>
                     <Nav.Link href="/faq">FAQ</Nav.Link>
-                    <Nav.Link href="/docs">Docs</Nav.Link>
                 </Nav>
             </Navbar.Collapse>
             <Nav>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,9 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import './index.css';
 import App from './components/App';
 import reportWebVitals from './reportWebVitals';
+import {BrowserRouter, Route, Routes} from "react-router-dom";
+import FAQ from "./components/FAQ";
+import NoPage from "./components/NoPage";
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
@@ -20,7 +23,13 @@ const getApiUrl = () => {
 
 root.render(
   <React.StrictMode>
-    <App />
+      <BrowserRouter>
+          <Routes>
+              <Route path="/" element={<App />} />
+                  <Route path="FAQ" element={<FAQ />} />
+                  <Route path="*" element={<NoPage />} />
+          </Routes>
+      </BrowserRouter>
   </React.StrictMode>
 );
 

--- a/test/components/FAQ.test.tsx
+++ b/test/components/FAQ.test.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import {render, screen} from "@testing-library/react";
+import FAQ from "../../src/components/FAQ";
+
+describe("<FAQ />", () => {
+    test("renders FAQ", async () => {
+
+        render(<FAQ/>);
+        const list = await screen.findAllByRole("listitem");
+        expect(list.length).toBe(5);
+    });
+});

--- a/test/components/NoPage.test.tsx
+++ b/test/components/NoPage.test.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import {render, screen} from "@testing-library/react";
+import NoPage from "../../src/components/NoPage";
+
+describe("<NoPage />", () => {
+    test("renders page not found message", async () => {
+
+        render(<NoPage/>);
+        const message = await screen.findByRole("heading");
+        expect(message.textContent).toBe("Page not found");
+    });
+});

--- a/test/components/TopNav.test.tsx
+++ b/test/components/TopNav.test.tsx
@@ -8,6 +8,12 @@ import {
 } from "../../src/RootContext";
 import TopNav from "../../src/components/TopNav";
 
+test("Displays FAQ link", async () => {
+    render(<TopNav theme={"light"} setTheme={jest.fn()}/>);
+    const faq = screen.getByText("FAQ") as HTMLAnchorElement;
+    expect(faq.href).toBe("http://localhost/faq");
+});
+
 test("user can end session", async () => {
     mockAxios.onDelete(`/session/`)
         .reply(200, mockSuccess("OK"));


### PR DESCRIPTION
This PR:
* adds GitHub action to run on an hourly schedule, hit the deployed API and force a cleanup of inactive session files
* adds react-router to support mutliple pages
* adds FAQ page

Closes #31 