### PR TITLE
slash on api route

### DIFF
--- a/src/components/PublicDatasets.tsx
+++ b/src/components/PublicDatasets.tsx
@@ -33,7 +33,7 @@ export default function PublicDatasets() {
                                 <li key={d.name} className={"mt-4"}>
                                     <h5>{d.name}</h5>
                                     <Link
-                                        to={`/dataset/public/${d.name}`}>View<ExternalLinkIcon
+                                        to={`/dataset/public/${d.name}/`}>View<ExternalLinkIcon
                                         className={"ms-1"}
                                         style={{marginTop: "-5px"}}></ExternalLinkIcon></Link> /
                                     <a href={`${apiUrl}/public/dataset/${d.name}`}

--- a/src/components/PublicDatasets.tsx
+++ b/src/components/PublicDatasets.tsx
@@ -33,10 +33,10 @@ export default function PublicDatasets() {
                                 <li key={d.name} className={"mt-4"}>
                                     <h5>{d.name}</h5>
                                     <Link
-                                        to={`/dataset/public/${d.name}/`}>View<ExternalLinkIcon
+                                        to={`/dataset/public/${d.name}`}>View<ExternalLinkIcon
                                         className={"ms-1"}
                                         style={{marginTop: "-5px"}}></ExternalLinkIcon></Link> /
-                                    <a href={`${apiUrl}/public/dataset/${d.name}`}
+                                    <a href={`${apiUrl}/public/dataset/${d.name}/`}
                                        className={"ps-1"}>Download<DownloadIcon
                                         className={"ms-1"}
                                         style={{marginTop: "-5px"}}></DownloadIcon></a>

--- a/test/components/PublicDatasets.test.tsx
+++ b/test/components/PublicDatasets.test.tsx
@@ -67,6 +67,6 @@ describe("<PublicDatatsets/>", () => {
     it("use can download csv", () => {
         renderComponent(state, jest.fn());
         const link = screen.getAllByRole<HTMLLinkElement>("link")[1];
-        expect(link.href).toBe("http://localhost/api/public/dataset/d1");
+        expect(link.href).toBe("http://localhost/api/public/dataset/d1/");
     });
 });


### PR DESCRIPTION
nb. trailing slash redirects don't work on the deployed site, which isn't ideal